### PR TITLE
documentation change

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Isn't it simply amazing to see these demos, where they throw a bunch of php,
 ruby, Java or python code at a Cloud Foundry site and it gets magically
 turned into a running web applications.  Alas for me, life is often a wee
 bit more complicated than that.  My projects always seem to required a few
-extra libraries or they are even written in an dead scripting language like
-Perl.
+extra libraries or they are written in a language that doesn't have a specific
+buildpack.
 
 That's where `sourcey-buildpack` comes in. It allows you to easily compile
 any libraries and binaries from source.  It takes care of putting everything


### PR DESCRIPTION
I understand Perl is not everyone most popular language but there's thousands of us at least and a lot of applications out there running important business loads.  Its probably ideal to keep opinions out of README docs right?   Your aggressive language immediately biased me against the Cloud Foundry project since we do have Perl and if I think we're going to not get the support we need than we should choose a different approach.  Just something for you to think about PR wise.  